### PR TITLE
remove the site.url

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,7 +1,6 @@
 site:
   title: Open Liberty Docs
-  start_page: ROOT::overview.adoc
-  url: https://openliberty.io
+  start_page: ROOT::overview.ado
 content:
   sources:
   # Test one component with each doc type being a module in it


### PR DESCRIPTION
Currently the site.url is breaking the build due to 404 page not being rendered; while we wait for a possible fix to make it into ol.io, revert this.