### PR TITLE
Add site.url to enable page.canonicalUrl""

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,6 +1,7 @@
 site:
   title: Open Liberty Docs
   start_page: ROOT::overview.adoc
+  url: https://openliberty.io
 content:
   sources:
   # Test one component with each doc type being a module in it


### PR DESCRIPTION
This is a double revert to re-enable the site.url in the playbook.