### PR TITLE
Revert "Add site.url to enable page.canonicalUrl"""

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,7 +1,6 @@
 site:
   title: Open Liberty Docs
   start_page: ROOT::overview.adoc
-  url: https://openliberty.io
 content:
   sources:
   # Test one component with each doc type being a module in it


### PR DESCRIPTION
Reverts OpenLiberty/docs-playbook#31

This is breaking the draft build. We will figure out how to build the site with the site.url property set before trying again.