### PR TITLE
Only include draft branch for docs-generated

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -6,7 +6,7 @@ content:
   - url: https://github.com/OpenLiberty/docs.git
     branches: [v*.0.0.*-draft, draft]
   - url: https://github.com/OpenLiberty/docs-generated.git
-    branches: [v*.0.0.*-draft, draft]
+    branches: [draft]
     
 asciidoc:
   attributes:


### PR DESCRIPTION
To speed up build & deploy time for draft sites, only include the latest ('draft') branch for docs-generated, but continue to include all versions from docs repo.