### PR TITLE
For draft sites, only clone the latest draft

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -4,7 +4,7 @@ site:
 content:
   sources:
   - url: https://github.com/OpenLiberty/docs.git
-    branches: [v*.0.0.*-draft, draft]
+    branches: [draft]
   - url: https://github.com/OpenLiberty/docs-generated.git
     branches: [draft]
     


### PR DESCRIPTION
Currently our feature parsing script can't deal with the content missing; for now, just going to set both repos to 'draft' only and we can revisit this