### PR TITLE
Update doc-redirects.properties

### DIFF
--- a/doc-redirects.properties
+++ b/doc-redirects.properties
@@ -4,6 +4,15 @@
 /config=/docs/ref/config/
 /config/*=/docs/ref/config/#
 
+# Redirect the pre-Antora docs URLS to the new URL format post-Antora
+# Note that we are purposefully not redirecting these four URL patterns if they just end with "/"
+# (e.g. nothing for the wildcard to match) because that's handled client-side in order
+# to redirect our old hash based URLs via JS in antora-redirect.js
+/docs/ref/general/*=/docs/latest/
+/docs/ref/config/*=/docs/latest/reference/config/
+/docs/ref/command/*=/docs/latest/reference/command/
+/docs/ref/feature/*=/docs/latest/reference/feature/
+
 # Redirects for a file name change to feature-overview.html. 20.0.0.8 was the latest version with the old file name.
 /docs/ref/feature/featureOverview.html=/docs/latest/reference/feature/feature-overview.html
 /docs/20.0.0.7/reference/feature/featureOverview.html=/docs/20.0.0.7/reference/feature/feature-overview.html
@@ -42,15 +51,6 @@
 /docs/20.0.0.9/=/docs/20.0.0.9/overview.html
 /docs/20.0.0.8/=/docs/20.0.0.8/overview.html
 /docs/20.0.0.7/=/docs/20.0.0.7/overview.html
-
-# Redirect the pre-Antora docs URLS to the new URL format post-Antora
-# Note that we are purposefully not redirecting these four URL patterns if they just end with "/"
-# (e.g. nothing for the wildcard to match) because that's handled client-side in order
-# to redirect our old hash based URLs via JS in antora-redirect.js
-/docs/ref/general/*=/docs/latest/
-/docs/ref/config/*=/docs/latest/reference/config/
-/docs/ref/command/*=/docs/latest/reference/command/
-/docs/ref/feature/*=/docs/latest/reference/feature/
 
 # Javadocs pre-Antora to post-Antora
 /docs/ref/javaee/7/=/docs/latest/reference/javadoc/liberty-javaee7-javadoc.html
@@ -99,7 +99,7 @@
 
 # Doc redirects that existed pre-Antora
 /docs/intro/=/docs/
-/docs/intro/microprofile.html=/docs/ref/general/#microprofile.html
+/docs/intro/microprofile.html=/docs/latest/microprofile.html
 /docs/ref/=/docs/
 /docs/ref/javaee/=/docs/ref/javaee/8/
 /docs/ref/microprofile/=/docs/ref/microprofile/3.3/


### PR DESCRIPTION
Moved the wild card redirects for /docs/ref/config/* to above where there is a more specific redirect for `docs/ref/config/serverConfiguration.html=/docs/latest/reference/config/server-configuration-overview.html` which was not being fired because of the wildcard.