### PR TITLE
Update doc-redirects.properties

### DIFF
--- a/doc-redirects.properties
+++ b/doc-redirects.properties
@@ -19,15 +19,21 @@
 /docs/20.0.0.8/reference/feature/featureOverview.html=/docs/20.0.0.8/reference/feature/feature-overview.html
 
 # Redirects for a file name change to server-configuration-overview.html. 20.0.0.8 was the latest version with the old file name.
-/docs/ref/config/serverConfiguration.html=/docs/latest/reference/config/server-configuration-overview.html
 /docs/20.0.0.7/reference/config/serverConfiguration.html=/docs/20.0.0.7/reference/config/server-configuration-overview.html
 /docs/20.0.0.8/reference/config/serverConfiguration.html=/docs/20.0.0.8/reference/config/server-configuration-overview.html
 
 # Temporary redirect until https://github.com/OpenLiberty/docs/issues/951 is merged
-/docs/latest/why-open-liberty.html=/
 /docs/20.0.0.10/why-open-liberty.html=/
 /docs/20.0.0.11/why-open-liberty.html=/
 /docs/20.0.0.12/why-open-liberty.html=/
+/docs/21.0.0.1/why-open-liberty.html=/
+/docs/21.0.0.2/why-open-liberty.html=/
+/docs/21.0.0.3/why-open-liberty.html=/
+/docs/21.0.0.4/why-open-liberty.html=/
+/docs/21.0.0.5/why-open-liberty.html=/
+/docs/21.0.0.6/why-open-liberty.html=/
+/docs/21.0.0.7/why-open-liberty.html=/
+/docs/21.0.0.8/why-open-liberty.html=/
 
 # Redirect the docs link in the header to the latest version
 /docs/=/docs/latest/


### PR DESCRIPTION
I removed two redirects that do not even work right now on production, and added versions of every why-open-liberty.html to redirect to / until that issue is resolved.