### PR TITLE
Update doc-redirects.properties

### DIFF
--- a/doc-redirects.properties
+++ b/doc-redirects.properties
@@ -36,6 +36,7 @@
 /docs/ref/config/serverConfiguration.html=/docs/latest/reference/config/server-configuration-overview.html
 /docs/20.0.0.7/reference/config/serverConfiguration.html=/docs/20.0.0.7/reference/config/server-configuration-overview.html
 /docs/20.0.0.8/reference/config/serverConfiguration.html=/docs/20.0.0.8/reference/config/server-configuration-overview.html
+/docs/latest/reference/config/serverConfiguration.html=/docs/latest/reference/config/server-configuration-overview.html
 
 # Temporary redirect until https://github.com/OpenLiberty/docs/issues/951 is merged
 /docs/latest/why-open-liberty.html=/


### PR DESCRIPTION
Fix broken link: 
https://openliberty.io/docs/ref/config/serverConfiguration.html
which should resolve as
https://openliberty.io/docs/latest/reference/config/server-configuration-overview.html