### PR TITLE
Revert "Update antora-playbook.yml"

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -6,7 +6,7 @@ content:
   - url: https://github.com/OpenLiberty/docs.git
     branches: [v*.0.0.*-draft, '!v20.0.0.*-draft', '!v21.0.0.1-draft', '!v21.0.0.2-draft', '!v21.0.0.3-draft', '!v21.0.0.4-draft','!v21.0.0.5-draft','!v21.0.0.6-draft', draft]
   - url: https://github.com/OpenLiberty/docs-generated.git
-    branches: [v23.0.0.6-draft, draft]
+    branches: [draft]
 urls:
   latest_version_segment: latest 
 antora:


### PR DESCRIPTION
Reverts OpenLiberty/docs-playbook#297

This was a temporary change to test the api/spi on draft. The hope is that this change was only required due to the api/spi being backport to an older version of docs `23.0.0.6`. Currently the draft site has `23.0.0.7` as the `latest` Antora catalog version. When the next round of api/spi are delivered, they should be aligned with the release schedule and be delivered into the `draft` branch.

The reason `docs-generated` is only pulling in `draft` is that historically the draft site is a leaner and faster building site. Staging site is where the full docs catalog is tested.

For https://github.com/OpenLiberty/openliberty.io/issues/1550