### PR TITLE
Restore all docs versions

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -4,7 +4,7 @@ site:
 content:
   sources:
   - url: https://github.com/OpenLiberty/docs.git
-    branches: [v*.0.0.*-draft, '!v20.0.0.*-draft', '!v21.0.0.1-draft', '!v21.0.0.2-draft', '!v21.0.0.3-draft', '!v21.0.0.4-draft','!v21.0.0.5-draft','!v21.0.0.6-draft','!v21.0.0.7-draft','!v21.0.0.8-draft','!v21.0.0.10-draft','!v21.0.0.11-draft', draft]
+    branches: [v*.0.0.*-draft, '!v20.0.0.*-draft', '!v21.0.0.1-draft', '!v21.0.0.2-draft', '!v21.0.0.3-draft', '!v21.0.0.4-draft','!v21.0.0.5-draft','!v21.0.0.6-draft','!v21.0.0.7-draft', draft]
   - url: https://github.com/OpenLiberty/docs-generated.git
     branches: [draft]
 urls:


### PR DESCRIPTION
With a fix made to the build process, we should now be able to host all doc versions from the past two years